### PR TITLE
docs(readme): renombrar Vibratools → Syndatools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,25 @@
-# VibraTools – SYNDAverse
+# Syndatools – SYNDAverse
 
-**VibraTools** es la familia de aplicaciones de SYNDAverse que utilizan la **mecánica resonante (TRU)** para transformar distintos sectores:
+Syndatools es la familia de aplicaciones de SYNDAverse que utilizan la mecánica resonante (TRU) para transformar distintos sectores:
 
-## 🔹 Herramientas actuales
+🔹 **Herramientas actuales**
 - **Vibramed** → Medicina vibratoria de precisión: diagnóstico y terapias resonantes.
 - **Vibragro** → Agricultura resonante: adaptación de entornos (invernaderos armónicos) para producir alimentos en cualquier lugar del mundo.
 
-## 🔹 Herramientas en desarrollo
+🔹 **Herramientas en desarrollo**
 - **VibraEnergy** → Energía del vacío y captura coherente.
 - **VibraHabitat** → Arquitectura y hábitats resonantes.
 - **VibraInfra** → Infraestructura nodal: telecomunicaciones y transporte.
 
----
-
 ## 📂 Roadmap
-1. Documentar Vibramed y Vibragro como repos separados.
-2. Definir arquitectura técnica para Vibramed (salud) y Vibragro (agricultura).
-3. Diseñar pilotos de VibraEnergy, VibraHabitat y VibraInfra.
-4. Integrar todas las herramientas bajo un mismo Hub (`vibratools`).
-
----
+- Documentar Vibramed y Vibragro como repos separados.
+- Definir arquitectura técnica para Vibramed (salud) y Vibragro (agricultura).
+- Diseñar pilotos de VibraEnergy, VibraHabitat y VibraInfra.
+- Integrar todas las herramientas bajo un mismo Hub (**Syndatools**).
 
 ## 🌐 Ecosistema SYNDAverse
-VibraTools se conecta con el resto de SYNDAverse:
-
-- [Syndaverse Dashboard](https://github.com/<tuusuario>/syndaverse-dashboard)
-- [TRU-e Calculator](https://github.com/<tuusuario>/tru-e-calculator)
-- [Onboarding Empresas](https://github.com/<tuusuario>/onboarding-enterprises)
-- [Onboarding Agentes](https://github.com/<tuusuario>/onboarding-agents)
+Syndatools se conecta con el resto de SYNDAverse:
+- Syndaverse Dashboard
+- TRU-e Calculator
+- Onboarding Empresas
+- Onboarding Agentes


### PR DESCRIPTION
### ¿Qué cambia?
Renombramos **Vibratools** a **Syndatools** en el README principal para alinear marca y navegación.

### Detalle
- Título actualizado: *Syndatools – SYNDAverse*.
- Reemplazo de menciones textuales a “Vibratools” → “Syndatools”.
- Roadmap y referencias internas apuntan ahora al Hub **Syndatools**.

### Impacto
- **Solo documentación.** No hay cambios de código ni build.
- Riesgo bajo.

### Checklist
- [x] README actualizado.
- [ ] (Opcional) Actualizar descripción del repo y topics en GitHub.
- [ ] (Opcional) Crear redirecciones si hay rutas `/vibratools` en la web.
- [ ] (Opcional) Variables de entorno: añadir `SYNDATOOLS_*` con fallback.

### Cómo probar
1. Abrir el README en el branch `christopherrichardson25-SYNDA-patch-1`.
2. Verificar que el nombre y las secciones reflejan **Syndatools**.

<!-- Relaciona issues si aplica: -->
Closes #<num-issue-si-corresponde>
